### PR TITLE
Invoke packer binary from pkenv root

### DIFF
--- a/libexec/pkenv-use
+++ b/libexec/pkenv-use
@@ -39,5 +39,5 @@ target_path=${PKENV_ROOT}/versions/${version}
 
 info "Switching to v${version}"
 echo "${version}" > "$(pkenv-version-file)" || error_and_die "'switch to v${version} failed'"
-packer version 1>/dev/null || error_and_die "'packer version' failed. Something is seriously wrong"
+${PKENV_ROOT}/bin/packer version 1>/dev/null || error_and_die "'packer version' failed. Something is seriously wrong"
 info "Switching completed"


### PR DESCRIPTION
- as per https://www.packer.io/intro/getting-started/install.html, On some RedHat-based Linux distributions there is another tool named packer installed by default.

- to avoid hanging when using "pkenv use" command, packer binary will be invoked from pkenv root folder