### PR TITLE
Update list remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,6 @@ validation failure.
 If you use [.packer-version](#packer-version), `pkenv install` (no argument) will install the version written in it.
 ### Specify architecture
 
-Architecture other than the default amd64 can be specified with the `PKENV_ARCH` environment variable
-
-```console
-PKENV_ARCH=arm pkenv install 1.3.1
-```
-
 ### pkenv use
 Switch a version to use
 `latest` is a syntax to use the latest installed version

--- a/libexec/pkenv-install
+++ b/libexec/pkenv-install
@@ -30,24 +30,48 @@ if [ -f "${dst_path}/packer" ]; then
   exit 0
 fi
 
-PKENV_ARCH=${PKENV_ARCH:-amd64}
-case "$(uname -s)" in
-  Darwin*)
-    os="darwin_${PKENV_ARCH}"
-    ;;
-  MINGW64*)
-    os="windows_${PKENV_ARCH}"
-    ;;
-  MSYS_NT*)
-    os="windows_${PKENV_ARCH}"
-    ;;
-  CYGWIN_NT*)
-    os="windows_${PKENV_ARCH}"
+# Add support of ARM64 for Linux & Apple Silicon
+case "$(uname -m)" in
+  aarch64* | arm64*)
+    # There is no arm64 support for versions:
+    # < 0.11.15
+    # >= 0.12.0, < 0.12.30
+    # >= 0.13.0, < 0.13.5
+    if [[ "${version}" =~ 0\.(([0-9]|10))\.\d* ||
+          "${version}" =~ 0\.11\.(([0-9]|1[0-4]))$ ||
+          "${version}" =~ 0\.12\.(([0-9]|[1-2][0-9]))$ ||
+          "${version}" =~ 0\.13\.[0-4]$
+    ]]; then
+      TFENV_ARCH="${TFENV_ARCH:-amd64}";
+    else
+      TFENV_ARCH="${TFENV_ARCH:-arm64}";
+    fi;
     ;;
   *)
-    os="linux_${PKENV_ARCH}"
+    TFENV_ARCH="${TFENV_ARCH:-amd64}";
     ;;
-esac
+esac;
+
+case "$(uname -s)" in
+  Darwin*)
+    os="darwin_${TFENV_ARCH}";
+    ;;
+  MINGW64*)
+    os="windows_${TFENV_ARCH}";
+    ;;
+  MSYS_NT*)
+    os="windows_${TFENV_ARCH}";
+    ;;
+  CYGWIN_NT*)
+    os="windows_${TFENV_ARCH}";
+    ;;
+  FreeBSD*)
+    os="freebsd_${TFENV_ARCH}";
+    ;;
+  *)
+    os="linux_${TFENV_ARCH}";
+    ;;
+esac;
 
 keybase_bin="$(command -v keybase 2>/dev/null)"
 shasum_bin="$(command -v shasum 2>/dev/null)"

--- a/libexec/pkenv-install
+++ b/libexec/pkenv-install
@@ -42,34 +42,34 @@ case "$(uname -m)" in
           "${version}" =~ 0\.12\.(([0-9]|[1-2][0-9]))$ ||
           "${version}" =~ 0\.13\.[0-4]$
     ]]; then
-      TFENV_ARCH="${TFENV_ARCH:-amd64}";
+      PKENV_ARCH="${PKENV_ARCH:-amd64}";
     else
-      TFENV_ARCH="${TFENV_ARCH:-arm64}";
+      PKENV_ARCH="${PKENV_ARCH:-arm64}";
     fi;
     ;;
   *)
-    TFENV_ARCH="${TFENV_ARCH:-amd64}";
+    PKENV_ARCH="${PKENV_ARCH:-amd64}";
     ;;
 esac;
 
 case "$(uname -s)" in
   Darwin*)
-    os="darwin_${TFENV_ARCH}";
+    os="darwin_${PKENV_ARCH}";
     ;;
   MINGW64*)
-    os="windows_${TFENV_ARCH}";
+    os="windows_${PKENV_ARCH}";
     ;;
   MSYS_NT*)
-    os="windows_${TFENV_ARCH}";
+    os="windows_${PKENV_ARCH}";
     ;;
   CYGWIN_NT*)
-    os="windows_${TFENV_ARCH}";
+    os="windows_${PKENV_ARCH}";
     ;;
   FreeBSD*)
-    os="freebsd_${TFENV_ARCH}";
+    os="freebsd_${PKENV_ARCH}";
     ;;
   *)
-    os="linux_${TFENV_ARCH}";
+    os="linux_${PKENV_ARCH}";
     ;;
 esac;
 

--- a/libexec/pkenv-list-remote
+++ b/libexec/pkenv-list-remote
@@ -10,4 +10,4 @@ fi
 
 PKENV_REMOTE="${PKENV_REMOTE:-https://releases.hashicorp.com}"
 
-curlw -sf "${PKENV_REMOTE}/packer/" | grep -o -E "[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta)[0-9]+)?" | uniq
+curlw -sf "${PKENV_REMOTE}/packer/" | grep -o -E "[0-9]+\.[0-9]+\.[0-9]+(-(alpha|rc|beta)([0-9]+)*)?" | uniq


### PR DESCRIPTION
```
04:30:14 ubuntu@8d177be1a2a0 ~ → pkenv list
* 1.8.5 (set by /home/ubuntu/.pkenv/version)
04:30:16 ubuntu@8d177be1a2a0 ~ → pkenv list-remote | head
1.9.0-alpha
1.8.6
1.8.5
1.8.4
1.8.3
1.8.2
1.8.1
1.8.0
1.7.10
1.7.9
04:30:25 ubuntu@8d177be1a2a0 ~ → pkenv install latest
[INFO] Installing Packer v1.8.6
[INFO] Downloading release tarball from https://releases.hashicorp.com/packer/1.8.6/packer_1.8.6_linux_arm64.zip
######################################################################################################################## 100.0%
[INFO] Downloading SHA hash file from https://releases.hashicorp.com/packer/1.8.6/packer_1.8.6_SHA256SUMS
pkenv: pkenv-install: [WARN] No keybase install found, skipping OpenPGP signature verification
Archive:  pkenv_download.fHTLIt/packer_1.8.6_linux_arm64.zip
  inflating: /home/ubuntu/.pkenv/versions/1.8.6/packer  
[INFO] Installation of packer v1.8.6 successful
[INFO] Switching to v1.8.6
[INFO] Switching completed
04:30:41 ubuntu@8d177be1a2a0 ~ → pkenv list
* 1.8.6 (set by /home/ubuntu/.pkenv/version)
  1.8.5
04:30:43 ubuntu@8d177be1a2a0 ~ → 
```