### PR TITLE
Add alpha check

### DIFF
--- a/libexec/pkenv-list-remote
+++ b/libexec/pkenv-list-remote
@@ -10,4 +10,4 @@ fi
 
 PKENV_REMOTE="${PKENV_REMOTE:-https://releases.hashicorp.com}"
 
-curlw -sf "${PKENV_REMOTE}/packer/" | grep -o -E "[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta|alpha)[0-9]+)?" | uniq
+curlw -sf "${PKENV_REMOTE}/packer/" | grep -o -E "[0-9]+\.[0-9]+\.[0-9]+(-((rc|beta)[0-9]+|alpha))?" | uniq

--- a/libexec/pkenv-list-remote
+++ b/libexec/pkenv-list-remote
@@ -10,4 +10,4 @@ fi
 
 PKENV_REMOTE="${PKENV_REMOTE:-https://releases.hashicorp.com}"
 
-curlw -sf "${PKENV_REMOTE}/packer/" | grep -o -E "[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta)[0-9]+)?" | uniq
+curlw -sf "${PKENV_REMOTE}/packer/" | grep -o -E "[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta|alpha)[0-9]+)?" | uniq


### PR DESCRIPTION
Packer version '1.9.0-alpha' listed in the hashicorp remote was not being caught properly so tried installing '1.9.0' which fails with a 404.